### PR TITLE
spearly-content-listのorder-byは文字列を受け付けるようにする

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ export default {}
 - `limit` (number, 10)
 - `offset` (number, 0)
 - `order` ('desc' | 'asc', 'desc')
-- `order_by` ('latest' | 'popular')
+- `order_by` ('latest' | 'popular' | string)
 - `filter_by` (string)
 - `filter_value` (string)
 - `filter_ref` (string)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@unimal-jp/nuxt-spearly-cms-module",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2444,9 +2444,9 @@
       }
     },
     "@unimal-jp/spearly-sdk-js": {
-      "version": "0.1.4",
-      "resolved": "https://npm.pkg.github.com/download/@unimal-jp/spearly-sdk-js/0.1.4/2752f41b747620ad8d5e95a0f19cfafa51ff4300358e2f440b8421874ef9bd4f",
-      "integrity": "sha512-ILz4NrUTkfZIJsh8ip3EgZl4hQJGjDDga7a0Z9WDkR+WQQvEOajB6gaOFVx7tL5o8cngTcNzr8aSRAdw0OHYHw==",
+      "version": "0.1.5",
+      "resolved": "https://npm.pkg.github.com/download/@unimal-jp/spearly-sdk-js/0.1.5/083c9567ab8577fe566ace8d2f8e8dcb7754988249d7d6ec7b8556618dc8c6d6",
+      "integrity": "sha512-EWRCSzYaYoowu5w82TXi/WhYHr0ZJ24l9c9ltJ1TxVYw3D1ZAPKXsTll4D2NdxVAFvMWBltNt9DAAzb0KL0GWA==",
       "requires": {
         "node-fetch": "^2.6.1"
       }

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
   "dependencies": {
     "@nuxt/types": "^2.15.7",
     "@types/node-fetch": "^2.5.12",
-    "@unimal-jp/spearly-sdk-js": "0.1.4",
+    "@unimal-jp/spearly-sdk-js": "0.1.5",
     "@vue/compiler-sfc": "^3.2.2",
     "node-fetch": "^2.6.1",
     "typescript": "^4.3.5",

--- a/src/components/spearly-content-list.vue
+++ b/src/components/spearly-content-list.vue
@@ -44,9 +44,7 @@ export default Vue.extend<Data, unknown, unknown, Props>({
     if (this.limit) params.limit = this.limit
     if (this.offset) params.offset = this.offset
     if (this.order && ['asc', 'desc'].includes(this.order)) params.order = this.order as 'desc' | 'asc'
-    if (this.orderBy && ['latest', 'popular'].includes(this.orderBy)) {
-      params.orderBy = this.orderBy as 'latest' | 'popular'
-    }
+    if (this.orderBy) params.orderBy = this.orderBy
     if (this.filterBy) params.filterBy = this.filterBy
     if (this.filterValue) params.filterValue = this.filterValue
     if (this.filterRef) params.filterRef = this.filterRef


### PR DESCRIPTION
## 概要
- `order_by` は `latest` 、 `popular` 以外にも受け付けていたため、文字列を受け付けられるようにした