### PR TITLE
readmeのページングの説明を修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ Since the `pager slot has a `paging` scope, you can freely create paginations wi
           {{ item.content.fields.title.value }}
         </nuxt-link>
       </template>
-      <template #paging="data">
+      <template #pager="data">
         <button v-if="data.paging.offset > 0" @click="offset -= 10">Previous</button>
         <button v-if="data.paging.next > 0" @click="offset += 10">Next</button>
       </template>


### PR DESCRIPTION
## 修正内容
Readmeのページネーション 埋め込みの説明を変更しました。

## テスト内容
Readmeの内容でページネーション 埋め込みができること

## 関連リンク
https://unimal.slack.com/archives/CH7RKDVEK/p1647569560284309?thread_ts=1647488708.912599&cid=CH7RKDVEK