### PR TITLE
Use validation set in CMS to v3

### DIFF
--- a/src/runtime/components/spearly-form/index.vue
+++ b/src/runtime/components/spearly-form/index.vue
@@ -240,6 +240,7 @@ const fetchFormLatest = async () => {
         description: res.confirmationEmail.description,
         order: 0,
         required: true,
+        validationRegex: '',
       })
     }
   } catch (error) {
@@ -304,8 +305,14 @@ const validate = () => {
   })
 
   telFields.forEach((identifier) => {
-    if (state.answers[identifier] && !/^[0-9\-]+$/.test(state.answers[identifier] as string)) {
-      state.errors.set(identifier, '電話番号を入力してください。')
+    const field = state.form.fields.find((field) => field.identifier === identifier)
+    if (!field.validationRegex) return
+
+    const regex = new RegExp(field.validationRegex)
+
+    if (state.answers[identifier] && !regex.test(state.answers[identifier] as string)) {
+      const format = field.validationRegex === '^[+]?\\d+$' ? 'ハイフンなし' : '半角数字とハイフン'
+      state.errors.set(identifier, `電話番号（${format}）を入力してください。`)
     }
   })
 

--- a/src/runtime/types/spearly-form-field.ts
+++ b/src/runtime/types/spearly-form-field.ts
@@ -11,4 +11,5 @@ export type SpearlyFormField = {
   name: string
   order: number
   required: boolean
+  validationRegex: string
 }


### PR DESCRIPTION
## Overview
Enable validation set up in Spearly CMS
(However, this option is currently only available for `tel` .)

## Change Description
- add `validationRegex` to SpearlyFormField
- if input_type is `tel` , use `validation_regex` value in the CMS response