### PR TITLE
Add select type to form field (to Nuxt v3)

### DIFF
--- a/src/runtime/components/spearly-form/index.vue
+++ b/src/runtime/components/spearly-form/index.vue
@@ -104,6 +104,20 @@
                 />
               </label>
             </template>
+            <template v-else-if="field.inputType === 'select_box'">
+              <select
+                :id="field.identifier"
+                v-model="state.answers[field.identifier]"
+                :require="field.required"
+                :disabled="!isActive"
+                :aria-invalid="!!state.errors.get(field.identifier)"
+                :aria-describedby="field.description ? `${field.identifier}-description` : null"
+              >
+                <option v-for="(option, i) in field.data.options" :key="i" :value="option">
+                  {{ option }}
+                </option>
+              </select>
+            </template>
 
             <p v-if="field.description" :id="`${field.identifier}-description`" class="spearly-form-field-description">
               {{ field.description }}

--- a/src/runtime/types/spearly-form-field-type.ts
+++ b/src/runtime/types/spearly-form-field-type.ts
@@ -8,3 +8,4 @@ export type SpearlyFormFieldType =
   | 'checkbox'
   | 'text_area'
   | 'file'
+  | 'select_box'


### PR DESCRIPTION
## Overview
CMS forms will be able to use select box, so `nuxt-module` also support it.

## Change Description
- add `select` element to `SpearlyForm`